### PR TITLE
perf: delay compression in the bulk indexer

### DIFF
--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -100,7 +100,7 @@ type bulkIndexerItem struct {
 // add encodes an item in the buffer.
 func (b *bulkIndexer) add(item bulkIndexerItem) error {
 	b.writeMeta(item.Index, item.Action, item.DocumentID)
-	if _, err := b.buf.ReadFrom(item.Body); err != nil {
+	if _, err := io.CopyBuffer(&b.buf, item.Body, nil); err != nil {
 		return err
 	}
 	if _, err := b.buf.WriteString("\n"); err != nil {

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -53,7 +53,6 @@ type bulkIndexer struct {
 	bytesFlushed int
 	jsonw        fastjson.Writer
 	gzipw        *gzip.Writer
-	copybuf      [32 * 1024]byte
 	buf          bytes.Buffer
 	resp         esutil.BulkIndexerResponse
 }
@@ -102,7 +101,7 @@ type bulkIndexerItem struct {
 // add encodes an item in the buffer.
 func (b *bulkIndexer) add(item bulkIndexerItem) error {
 	b.writeMeta(item.Index, item.Action, item.DocumentID)
-	if _, err := io.CopyBuffer(&b.buf, item.Body, b.copybuf[:]); err != nil {
+	if _, err := b.buf.ReadFrom(item.Body); err != nil {
 		return err
 	}
 	if _, err := b.buf.WriteString("\n"); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/elastic/go-elasticsearch/v8 v8.5.0
+	github.com/klauspost/compress v1.15.12
 	github.com/stretchr/testify v1.8.0
 	go.elastic.co/apm/module/apmelasticsearch/v2 v2.2.0
 	go.elastic.co/apm/module/apmzap/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/jcchavezs/porto v0.1.0/go.mod h1:fESH0gzDHiutHRdX2hv27ojnOVFco37hg1W6
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
+github.com/klauspost/compress v1.15.12 h1:YClS/PImqYbn+UILDnqxQCZ3RehC9N318SU3kElDUEM=
+github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
Port of https://github.com/elastic/apm-server/pull/9760

Write to a byte buffer instead of writing to the gzip writer, then compress the payload once we are about to flush it to ES. Benchmarks shows a significant improvement in cpu time and switching to an optimized gzip library improves the situation even further.

NOTE: the NoCompression benchmark shows no improvements as this change only affect the bulk indexer with compression enabled.

Updated benchmarks 1:

```
name                                   old time/op    new time/op     delta
Appender/NoCompression-20                 460ns ± 1%      452ns ± 4%    -1.79%  (p=0.028 n=8+10)
Appender/NoCompressionScaling-20          819ns ±11%      827ns ±10%      ~     (p=0.529 n=10+10)
Appender/BestSpeed-20                    1.22µs ±14%     0.48µs ± 6%   -61.02%  (p=0.000 n=10+10)
Appender/BestSpeedScaling-20             1.30µs ±12%     0.84µs ±13%   -35.15%  (p=0.000 n=10+10)
Appender/DefaultCompression-20           1.70µs ± 3%     0.49µs ± 4%   -71.26%  (p=0.000 n=10+10)
Appender/DefaultCompressionScaling-20    1.69µs ± 2%     0.85µs ±11%   -49.40%  (p=0.000 n=9+10)
Appender/BestCompression-20              1.68µs ± 3%     0.51µs ± 3%   -69.66%  (p=0.000 n=10+10)
Appender/BestCompressionScaling-20       1.69µs ± 1%     0.86µs ±13%   -49.15%  (p=0.000 n=10+10)

name                                   old speed      new speed       delta
Appender/NoCompression-20               291MB/s ± 1%    297MB/s ± 4%    +1.84%  (p=0.034 n=8+10)
Appender/NoCompressionScaling-20        165MB/s ±11%    163MB/s ± 9%      ~     (p=0.529 n=10+10)
Appender/BestSpeed-20                   108MB/s ± 5%    282MB/s ± 5%  +160.33%  (p=0.000 n=9+10)
Appender/BestSpeedScaling-20            104MB/s ±13%    159MB/s ±12%   +54.03%  (p=0.000 n=10+10)
Appender/DefaultCompression-20         79.0MB/s ± 3%  275.1MB/s ± 4%  +248.07%  (p=0.000 n=10+10)
Appender/DefaultCompressionScaling-20  79.4MB/s ± 2%  157.4MB/s ±10%   +98.17%  (p=0.000 n=9+10)
Appender/BestCompression-20            79.5MB/s ± 2%  262.3MB/s ± 3%  +229.72%  (p=0.000 n=10+10)
Appender/BestCompressionScaling-20     79.4MB/s ± 1%  156.9MB/s ±12%   +97.63%  (p=0.000 n=10+10)

name                                   old alloc/op   new alloc/op    delta
Appender/NoCompression-20                  514B ± 0%       510B ± 0%    -0.74%  (p=0.000 n=10+8)
Appender/NoCompressionScaling-20           528B ± 0%       527B ± 1%      ~     (p=0.245 n=9+10)
Appender/BestSpeed-20                      981B ± 0%       694B ± 0%   -29.28%  (p=0.000 n=9+10)
Appender/BestSpeedScaling-20               986B ± 0%       713B ± 1%   -27.71%  (p=0.000 n=9+10)
Appender/DefaultCompression-20             987B ± 1%       695B ± 0%   -29.52%  (p=0.000 n=9+10)
Appender/DefaultCompressionScaling-20      968B ± 5%       714B ± 1%   -26.24%  (p=0.000 n=10+10)
Appender/BestCompression-20                990B ± 1%       697B ± 0%   -29.61%  (p=0.000 n=10+10)
Appender/BestCompressionScaling-20         985B ± 1%       716B ± 1%   -27.30%  (p=0.000 n=8+10)

name                                   old allocs/op  new allocs/op   delta
Appender/NoCompression-20                  7.00 ± 0%       6.00 ± 0%   -14.29%  (p=0.000 n=10+10)
Appender/NoCompressionScaling-20           7.00 ± 0%       6.00 ± 0%   -14.29%  (p=0.000 n=10+10)
Appender/BestSpeed-20                      10.0 ± 0%        6.0 ± 0%   -40.00%  (p=0.000 n=10+10)
Appender/BestSpeedScaling-20               10.0 ± 0%        6.0 ± 0%   -40.00%  (p=0.000 n=10+10)
Appender/DefaultCompression-20             10.0 ± 0%        6.0 ± 0%   -40.00%  (p=0.000 n=10+10)
Appender/DefaultCompressionScaling-20      10.0 ± 0%        6.0 ± 0%   -40.00%  (p=0.000 n=10+10)
Appender/BestCompression-20                10.0 ± 0%        6.0 ± 0%   -40.00%  (p=0.000 n=10+10)
Appender/BestCompressionScaling-20         10.0 ± 0%        6.0 ± 0%   -40.00%  (p=0.000 n=10+10)
```